### PR TITLE
Increase threshold (higher acc, lower RT) for block-level feedback for all tasks

### DIFF
--- a/ax_cpt_rdoc/experiment.js
+++ b/ax_cpt_rdoc/experiment.js
@@ -231,8 +231,8 @@ var runAttentionChecks = true;
 /* ******************************* */
 
 var practiceThresh = 3; // 3 blocks max
-var accuracyThresh = 0.75; // min accuracy to proceed to test
-var rtThresh = 1000; // min of 1s on instructions to proceed to practice
+var accuracyThresh = 0.85; // min accuracy to proceed to test
+var rtThresh = 750; // min of 1s on instructions to proceed to practice
 var missedResponseThresh = 0.1; // get feedback if missed responses > 10% of trials
 
 /* ******************************* */

--- a/cued_task_switching_rdoc/experiment.js
+++ b/cued_task_switching_rdoc/experiment.js
@@ -433,9 +433,9 @@ var numTrialsPerBlock = 64;
 var numTestBlocks = 3;
 
 var practiceThresh = 3; // 3 blocks of 16 trials
-var rtThresh = 1000;
+var rtThresh = 750;
 var missedResponseThresh = 0.1;
-var accuracyThresh = 0.75;
+var accuracyThresh = 0.85;
 
 var fileTypePNG = ".png'></img>";
 var preFileType =

--- a/flanker_rdoc/experiment.js
+++ b/flanker_rdoc/experiment.js
@@ -132,8 +132,8 @@ const stimTrialDuration = 1500;
 var sumInstructTime = 0; // ms
 var instructTimeThresh = 1; // /in seconds
 
-var accuracyThresh = 0.75;
-var rtThresh = 1000;
+var accuracyThresh = 0.85;
+var rtThresh = 750;
 var missedResponseThresh = 0.1;
 var practiceThresh = 3; // 3 blocks of 12 trials
 

--- a/go_nogo_rdoc/experiment.js
+++ b/go_nogo_rdoc/experiment.js
@@ -321,8 +321,8 @@ var testStimuliBlock = [
   })
 );
 
-var accuracyThresh = 0.75;
-var rtThresh = 1000;
+var accuracyThresh = 0.85;
+var rtThresh = 750;
 var missedResponseThresh = 0.1;
 
 var practiceLen = 7;

--- a/n_back_rdoc/experiment.js
+++ b/n_back_rdoc/experiment.js
@@ -378,8 +378,8 @@ var delay = 1;
 var nbackConditions = ["mismatch", "mismatch", "match", "mismatch", "mismatch"];
 var stims = createTrialTypes(practiceLen, delay);
 
-var accuracyThresh = 0.75;
-var rtThresh = 1000;
+var accuracyThresh = 0.8;
+var rtThresh = 750;
 var missedResponseThresh = 0.1;
 
 var pathSource = "/static/experiments/n_back_rdoc/images/";

--- a/span_rdoc__behavioral/experiment.js
+++ b/span_rdoc__behavioral/experiment.js
@@ -7129,11 +7129,11 @@ var missedResponseThresh = 0.1;
 var practiceThresh = 3;
 var processingChoices = ["t", "f"];
 
-var processingAccThresh = 0.6;
+var processingAccThresh = 0.85;
 var processingRTThresh = 1000;
-var processingMissedThresh = 0.2;
+var processingMissedThresh = 0.1;
 
-var practiceLen = 3;
+var practiceLen = 1;
 var numTrialsPerBlock = 8;
 var numTestBlocks = 3;
 

--- a/spatial_cueing_rdoc/experiment.js
+++ b/spatial_cueing_rdoc/experiment.js
@@ -239,8 +239,8 @@ var fixationDuration2 = Math.floor(Math.random() * 1200) + 400; // CTI
 var runAttentionChecks = true;
 
 var instructTimeThresh = 1; // in seconds
-var accuracyThresh = 0.75;
-var rtThresh = 1000;
+var accuracyThresh = 0.85;
+var rtThresh = 750;
 var missedResponseThresh = 0.1;
 var practiceThresh = 3;
 

--- a/spatial_task_switching_rdoc/experiment.js
+++ b/spatial_task_switching_rdoc/experiment.js
@@ -414,8 +414,8 @@ var practiceLen = 16; // divisible by 4,  2 (switch or stay) by 2 (mag or parity
 var numTrialsPerBlock = 64; //  divisible by 4
 var numTestBlocks = 3;
 
-var accuracy_thresh = 0.75;
-var rt_thresh = 1000;
+var accuracy_thresh = 0.85;
+var rt_thresh = 750;
 var missed_response_thresh = 0.1;
 var practice_thresh = 3; // 3 blocks of 16 trials
 

--- a/stop_signal_rdoc/experiment.js
+++ b/stop_signal_rdoc/experiment.js
@@ -371,9 +371,9 @@ var numTrialsPerBlock = 60; // must be divisible by shapes.length * stopSignalsC
 var numTestBlocks = 3;
 
 var practiceThresh = 3; // max number of times to repeat practice
-var accuracyThresh = 0.75;
+var accuracyThresh = 0.85;
 var missedResponseThresh = 0.1;
-var rtThresh = 1000;
+var rtThresh = 750;
 
 var SSD = 350;
 var maxSSD = 1000;

--- a/stroop_rdoc/experiment.js
+++ b/stroop_rdoc/experiment.js
@@ -252,8 +252,8 @@ const stimTrialDuration = 1500;
 var runAttentionChecks = true;
 var instructTimeThresh = 1;
 
-var accuracyThresh = 0.7;
-var rtThresh = 1000;
+var accuracyThresh = 0.85;
+var rtThresh = 750;
 var missedResponseThresh = 0.1;
 var practiceThresh = 3; // 3 blocks max
 

--- a/visual_search_rdoc/experiment.js
+++ b/visual_search_rdoc/experiment.js
@@ -363,8 +363,8 @@ var runAttentionChecks = true;
 // thresholds
 const instructTimeThresh = 1; // /in seconds
 var sumInstructTime = 0; // ms
-const accuracyThresh = 0.6;
-const rtThresh = 1000;
+const accuracyThresh = 0.85;
+const rtThresh = 1250;
 const missedResponseThresh = 0.1;
 
 // trial nums


### PR DESCRIPTION
Decided to make block-level feedback more challenging, since we have the functions in expfactory deploy that will capture really poor performance (around random-chance accuracy). 