### PR TITLE
Add Roundtable Proof-of-Human tracker to the 12 RDoC comparison tasks

### DIFF
--- a/ax_cpt_rdoc/experiment.js
+++ b/ax_cpt_rdoc/experiment.js
@@ -1,4 +1,20 @@
 /* ************************************ */
+/* Roundtable Proof-of-Human — invisible bot/human classification (rt.js).
+   Injected here because expfactory assembles the page from config.json's
+   run-list (src-only script tags); this carries the required data-site-key
+   attribute and a per-task data-tags for dashboard filtering. */
+(function () {
+  if (window.__roundtableInjected) return;
+  window.__roundtableInjected = true;
+  var s = document.createElement("script");
+  s.src = "https://cdn.roundtable.ai/v1/rt.js";
+  s.setAttribute("data-site-key", "pub-2rS0iJL0dtTNoNyPTpvm");
+  s.setAttribute("data-tags", "ax_cpt_rdoc");
+  (document.head || document.documentElement).appendChild(s);
+})();
+/* ************************************ */
+
+/* ************************************ */
 /* Define helper functions */
 /* ************************************ */
 

--- a/cued_task_switching_rdoc/experiment.js
+++ b/cued_task_switching_rdoc/experiment.js
@@ -1,4 +1,20 @@
 /* ************************************ */
+/* Roundtable Proof-of-Human — invisible bot/human classification (rt.js).
+   Injected here because expfactory assembles the page from config.json's
+   run-list (src-only script tags); this carries the required data-site-key
+   attribute and a per-task data-tags for dashboard filtering. */
+(function () {
+  if (window.__roundtableInjected) return;
+  window.__roundtableInjected = true;
+  var s = document.createElement("script");
+  s.src = "https://cdn.roundtable.ai/v1/rt.js";
+  s.setAttribute("data-site-key", "pub-2rS0iJL0dtTNoNyPTpvm");
+  s.setAttribute("data-tags", "cued_task_switching_rdoc");
+  (document.head || document.documentElement).appendChild(s);
+})();
+/* ************************************ */
+
+/* ************************************ */
 /* Define helper functions */
 /* ************************************ */
 

--- a/flanker_rdoc/experiment.js
+++ b/flanker_rdoc/experiment.js
@@ -1,4 +1,20 @@
 /* ************************************ */
+/* Roundtable Proof-of-Human — invisible bot/human classification (rt.js).
+   Injected here because expfactory assembles the page from config.json's
+   run-list (src-only script tags); this carries the required data-site-key
+   attribute and a per-task data-tags for dashboard filtering. */
+(function () {
+  if (window.__roundtableInjected) return;
+  window.__roundtableInjected = true;
+  var s = document.createElement("script");
+  s.src = "https://cdn.roundtable.ai/v1/rt.js";
+  s.setAttribute("data-site-key", "pub-2rS0iJL0dtTNoNyPTpvm");
+  s.setAttribute("data-tags", "flanker_rdoc");
+  (document.head || document.documentElement).appendChild(s);
+})();
+/* ************************************ */
+
+/* ************************************ */
 /* Define helper functions */
 /* ************************************ */
 // PARAMETERS FOR DECAYING EXPONENTIAL FUNCTION

--- a/go_nogo_rdoc/experiment.js
+++ b/go_nogo_rdoc/experiment.js
@@ -1,4 +1,20 @@
 /* ************************************ */
+/* Roundtable Proof-of-Human — invisible bot/human classification (rt.js).
+   Injected here because expfactory assembles the page from config.json's
+   run-list (src-only script tags); this carries the required data-site-key
+   attribute and a per-task data-tags for dashboard filtering. */
+(function () {
+  if (window.__roundtableInjected) return;
+  window.__roundtableInjected = true;
+  var s = document.createElement("script");
+  s.src = "https://cdn.roundtable.ai/v1/rt.js";
+  s.setAttribute("data-site-key", "pub-2rS0iJL0dtTNoNyPTpvm");
+  s.setAttribute("data-tags", "go_nogo_rdoc");
+  (document.head || document.documentElement).appendChild(s);
+})();
+/* ************************************ */
+
+/* ************************************ */
 /* Define helper functions */
 /* ************************************ */
 

--- a/n_back_rdoc/experiment.js
+++ b/n_back_rdoc/experiment.js
@@ -1,4 +1,20 @@
 /* ************************************ */
+/* Roundtable Proof-of-Human — invisible bot/human classification (rt.js).
+   Injected here because expfactory assembles the page from config.json's
+   run-list (src-only script tags); this carries the required data-site-key
+   attribute and a per-task data-tags for dashboard filtering. */
+(function () {
+  if (window.__roundtableInjected) return;
+  window.__roundtableInjected = true;
+  var s = document.createElement("script");
+  s.src = "https://cdn.roundtable.ai/v1/rt.js";
+  s.setAttribute("data-site-key", "pub-2rS0iJL0dtTNoNyPTpvm");
+  s.setAttribute("data-tags", "n_back_rdoc");
+  (document.head || document.documentElement).appendChild(s);
+})();
+/* ************************************ */
+
+/* ************************************ */
 /*       Define Helper Functions        */
 /* ************************************ */
 // PARAMETERS FOR DECAYING EXPONENTIAL FUNCTION

--- a/operation_span_rdoc/experiment.js
+++ b/operation_span_rdoc/experiment.js
@@ -1,3 +1,19 @@
+/* ************************************ */
+/* Roundtable Proof-of-Human — invisible bot/human classification (rt.js).
+   Injected here because expfactory assembles the page from config.json's
+   run-list (src-only script tags); this carries the required data-site-key
+   attribute and a per-task data-tags for dashboard filtering. */
+(function () {
+  if (window.__roundtableInjected) return;
+  window.__roundtableInjected = true;
+  var s = document.createElement("script");
+  s.src = "https://cdn.roundtable.ai/v1/rt.js";
+  s.setAttribute("data-site-key", "pub-2rS0iJL0dtTNoNyPTpvm");
+  s.setAttribute("data-tags", "operation_span_rdoc");
+  (document.head || document.documentElement).appendChild(s);
+})();
+/* ************************************ */
+
 const OG_CHEIN_SYMM_GRIDS = [
   [
     "black",

--- a/simple_span_rdoc/experiment.js
+++ b/simple_span_rdoc/experiment.js
@@ -1,3 +1,19 @@
+/* ************************************ */
+/* Roundtable Proof-of-Human — invisible bot/human classification (rt.js).
+   Injected here because expfactory assembles the page from config.json's
+   run-list (src-only script tags); this carries the required data-site-key
+   attribute and a per-task data-tags for dashboard filtering. */
+(function () {
+  if (window.__roundtableInjected) return;
+  window.__roundtableInjected = true;
+  var s = document.createElement("script");
+  s.src = "https://cdn.roundtable.ai/v1/rt.js";
+  s.setAttribute("data-site-key", "pub-2rS0iJL0dtTNoNyPTpvm");
+  s.setAttribute("data-tags", "simple_span_rdoc");
+  (document.head || document.documentElement).appendChild(s);
+})();
+/* ************************************ */
+
 /* ************************************ * /
 /* Define helper functions */
 /* ************************************ */

--- a/spatial_cueing_rdoc/experiment.js
+++ b/spatial_cueing_rdoc/experiment.js
@@ -1,4 +1,20 @@
 /* ************************************ */
+/* Roundtable Proof-of-Human — invisible bot/human classification (rt.js).
+   Injected here because expfactory assembles the page from config.json's
+   run-list (src-only script tags); this carries the required data-site-key
+   attribute and a per-task data-tags for dashboard filtering. */
+(function () {
+  if (window.__roundtableInjected) return;
+  window.__roundtableInjected = true;
+  var s = document.createElement("script");
+  s.src = "https://cdn.roundtable.ai/v1/rt.js";
+  s.setAttribute("data-site-key", "pub-2rS0iJL0dtTNoNyPTpvm");
+  s.setAttribute("data-tags", "spatial_cueing_rdoc");
+  (document.head || document.documentElement).appendChild(s);
+})();
+/* ************************************ */
+
+/* ************************************ */
 /* Define helper functions */
 /* ************************************ */
 // common

--- a/spatial_task_switching_rdoc/experiment.js
+++ b/spatial_task_switching_rdoc/experiment.js
@@ -1,4 +1,20 @@
 /* ************************************ */
+/* Roundtable Proof-of-Human — invisible bot/human classification (rt.js).
+   Injected here because expfactory assembles the page from config.json's
+   run-list (src-only script tags); this carries the required data-site-key
+   attribute and a per-task data-tags for dashboard filtering. */
+(function () {
+  if (window.__roundtableInjected) return;
+  window.__roundtableInjected = true;
+  var s = document.createElement("script");
+  s.src = "https://cdn.roundtable.ai/v1/rt.js";
+  s.setAttribute("data-site-key", "pub-2rS0iJL0dtTNoNyPTpvm");
+  s.setAttribute("data-tags", "spatial_task_switching_rdoc");
+  (document.head || document.documentElement).appendChild(s);
+})();
+/* ************************************ */
+
+/* ************************************ */
 /* Define helper functions */
 /* ************************************ */
 var meanITI = 0.5;

--- a/stop_signal_rdoc/experiment.js
+++ b/stop_signal_rdoc/experiment.js
@@ -1,4 +1,20 @@
 /* ************************************ */
+/* Roundtable Proof-of-Human — invisible bot/human classification (rt.js).
+   Injected here because expfactory assembles the page from config.json's
+   run-list (src-only script tags); this carries the required data-site-key
+   attribute and a per-task data-tags for dashboard filtering. */
+(function () {
+  if (window.__roundtableInjected) return;
+  window.__roundtableInjected = true;
+  var s = document.createElement("script");
+  s.src = "https://cdn.roundtable.ai/v1/rt.js";
+  s.setAttribute("data-site-key", "pub-2rS0iJL0dtTNoNyPTpvm");
+  s.setAttribute("data-tags", "stop_signal_rdoc");
+  (document.head || document.documentElement).appendChild(s);
+})();
+/* ************************************ */
+
+/* ************************************ */
 /*       Define Helper Functions        */
 /* ************************************ */
 // PARAMETERS FOR DECAYING EXPONENTIAL FUNCTION

--- a/stroop_rdoc/experiment.js
+++ b/stroop_rdoc/experiment.js
@@ -1,4 +1,20 @@
 /* ************************************ */
+/* Roundtable Proof-of-Human — invisible bot/human classification (rt.js).
+   Injected here because expfactory assembles the page from config.json's
+   run-list (src-only script tags); this carries the required data-site-key
+   attribute and a per-task data-tags for dashboard filtering. */
+(function () {
+  if (window.__roundtableInjected) return;
+  window.__roundtableInjected = true;
+  var s = document.createElement("script");
+  s.src = "https://cdn.roundtable.ai/v1/rt.js";
+  s.setAttribute("data-site-key", "pub-2rS0iJL0dtTNoNyPTpvm");
+  s.setAttribute("data-tags", "stroop_rdoc");
+  (document.head || document.documentElement).appendChild(s);
+})();
+/* ************************************ */
+
+/* ************************************ */
 /* Define helper functions */
 /* ************************************ */
 // common

--- a/visual_search_rdoc/experiment.js
+++ b/visual_search_rdoc/experiment.js
@@ -1,4 +1,20 @@
 /* ************************************ */
+/* Roundtable Proof-of-Human — invisible bot/human classification (rt.js).
+   Injected here because expfactory assembles the page from config.json's
+   run-list (src-only script tags); this carries the required data-site-key
+   attribute and a per-task data-tags for dashboard filtering. */
+(function () {
+  if (window.__roundtableInjected) return;
+  window.__roundtableInjected = true;
+  var s = document.createElement("script");
+  s.src = "https://cdn.roundtable.ai/v1/rt.js";
+  s.setAttribute("data-site-key", "pub-2rS0iJL0dtTNoNyPTpvm");
+  s.setAttribute("data-tags", "visual_search_rdoc");
+  (document.head || document.documentElement).appendChild(s);
+})();
+/* ************************************ */
+
+/* ************************************ */
 /* Define helper functions */
 /* ************************************ */
 // PARAMETERS FOR DECAYING EXPONENTIAL FUNCTION


### PR DESCRIPTION
Injects Roundtable's `rt.js` (invisible bot/human behavioral classification) at the top of each of the 12 RDoC comparison tasks' `experiment.js`:

ax_cpt, cued_task_switching, flanker, go_nogo, n_back, operation_span, simple_span, spatial_cueing, spatial_task_switching, stop_signal, stroop, visual_search.

**Why experiment.js:** expfactory assembles the page from `config.json`'s src-only run-list, so there's no HTML to carry `rt.js`'s required `data-site-key` attribute. Prepending a small script-append snippet to `experiment.js` (which every task loads) is the one injection point that carries the attribute. Each task passes its own `data-tags` (= exp_id) for per-task dashboard filtering, guarded against double-injection.

Scope: the 12 base comparison tasks only (screeners and non-comparison dirs excluded). All 12 verified to parse cleanly (`node --check`).